### PR TITLE
fix allowOutsideClick type mismatch

### DIFF
--- a/src/FocusTrap.ts
+++ b/src/FocusTrap.ts
@@ -72,7 +72,7 @@ const FocusTrap: FocusTrapComponent = {
             this.$el,
             {
               escapeDeactivates: this.escapeDeactivates,
-              allowOutsideClick: this.allowOutsideClick,
+              allowOutsideClick: () => this.allowOutsideClick,
               returnFocusOnDeactivate: this.returnFocusOnDeactivate,
               onActivate: () => {
                 this.$emit('update:active', true)


### PR DESCRIPTION
fix bug where focus-trap expects allowOutsideClick to be a function and vue component expects it to be a boolean

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#Pull-Request
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
