### PR TITLE
feat: function for the `allowOutsideClick` prop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ demo_dist
 cypress/videos
 demo/original.html
 temp
+.idea

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ always focus an interactable element instead of the modal container:
 
 - `escapeDeactivates`: `boolean`
 - `returnFocusOnDeactivate`: `boolean`
-- `allowOutsideClick`: `boolean`
+- `allowOutsideClick`: `boolean | ((e: MouseEvent) => boolean)`
 - `clickOutsideDeactivates`: `boolean`
 - `initialFocus`: `string | (() => Element)` _Selector or function returning an Element_
 - `fallbackFocus`: `string | (() => Element)` _Selector or function returning an

--- a/cypress/integration/basic.spec.js
+++ b/cypress/integration/basic.spec.js
@@ -42,10 +42,40 @@ describe('default behavior', () => {
       .get('#ocd .trap')
       .should('have.class', 'is-active')
       .get('body')
-      .click()
+      // force is needed because the vertical center of the body may not be
+      // visible and click always tries to click on the middle of an element
+      .click({ force: true })
       .focused()
       .should('not.have.class', 'trap')
       .get('#ocd .trap')
       .should('not.have.class', 'is-active')
   })
+
+  describe('conditionally allowing outside clicks', () => {
+    it('does not allow outside clicks when toggled off', () => {
+      cy.get('#aoc > p > button')
+        .click()
+        .get('#aoc .trap')
+        .should('have.class', 'is-active')
+        .get('#basic > p > button')
+        .click()
+        .get('#basic .trap')
+        .should('not.have.class', 'is-active')
+    })
+
+    it('allows outside clicks when toggled on', () => {
+     cy.get('#aoc > p input[type="checkbox"]')
+        .check()
+        .get('#aoc > p > button')
+        .click()
+        .get('#aoc .trap')
+        .should('have.class', 'is-active')
+        .get('#basic > p > button')
+        .click()
+        .get('#basic .trap')
+        .should('have.class', 'is-active')
+    })
+  })
+
+
 })

--- a/demo/index.html
+++ b/demo/index.html
@@ -182,6 +182,50 @@
           </div>
         </focus-trap>
       </section>
+
+      <section id="aoc">
+        <h2 id="aoc-heading">allow outside click</h2>
+        <p>
+          A callback function can be used to determine whether or not you
+          should be allowed to click outside of the focus trap when it's
+          deactivated.
+        </p>
+        <p>
+          <label>
+            <input type="checkbox" v-model="demos.aoc.clickOutsideEnabled">
+            Enable outside clicking
+          </label>
+        </p>
+        <p>
+          <button @click="demos.aoc.isActive = true">
+            activate trap
+          </button>
+        </p>
+
+        <focus-trap
+          v-model="demos.aoc.isActive"
+          :initial-focus="demos.aoc.initialFocus"
+          :allow-outside-click="demos.aoc.allowOutsideClick"
+        >
+          <div class="trap" :class="demos.aoc.isActive && 'is-active'">
+            <p>
+              Here is a focus trap <a href="#">with</a> <a href="#">some</a>
+              <a href="#">focusable</a> parts.
+            </p>
+            <p>
+              <label class="inline-label">
+                Initially focused input
+                <input ref="ocdInput" />
+              </label>
+            </p>
+            <p>
+              <button @click="demos.aoc.isActive = false">
+                deactivate trap
+              </button>
+            </p>
+          </div>
+        </focus-trap>
+      </section>
     </div>
   </body>
 </html>

--- a/demo/index.js
+++ b/demo/index.js
@@ -22,6 +22,11 @@ window.vm = new Vue({
           isActive: false,
           clickOutsideDeactivates: true
         },
+        aoc: {
+          clickOutsideEnabled: false,
+          isActive: false,
+          allowOutsideClick: () => this.demos.aoc.clickOutsideEnabled,
+        },
       }
     }
   },

--- a/src/FocusTrap.ts
+++ b/src/FocusTrap.ts
@@ -1,4 +1,4 @@
-import Vue, { ComponentOptions } from 'vue'
+import Vue, { PropType, ComponentOptions } from 'vue'
 // import Component from 'vue-class-component'
 import { createFocusTrap, FocusTrap as FocusTrapI } from 'focus-trap'
 
@@ -6,7 +6,7 @@ interface FocusTrapComponentProps {
   active: boolean
   escapeDeactivates: boolean
   returnFocusOnDeactivate: boolean
-  allowOutsideClick: boolean
+  allowOutsideClick: boolean | ((e: MouseEvent) => boolean)
   clickOutsideDeactivates: boolean
   initialFocus: string | (() => any)
   fallbackFocus: string | (() => any)
@@ -45,7 +45,7 @@ const FocusTrap: FocusTrapComponent = {
       default: true,
     },
     allowOutsideClick: {
-      type: Boolean,
+      type: [Boolean, Function] as PropType<FocusTrapComponentProps['allowOutsideClick']>,
       default: true,
     },
     clickOutsideDeactivates: {
@@ -72,7 +72,11 @@ const FocusTrap: FocusTrapComponent = {
             this.$el,
             {
               escapeDeactivates: this.escapeDeactivates,
-              allowOutsideClick: () => this.allowOutsideClick,
+              allowOutsideClick: (e: MouseEvent) => (
+                typeof this.allowOutsideClick === 'function'
+                ? this.allowOutsideClick(e)
+                : this.allowOutsideClick
+              ),
               clickOutsideDeactivates: this.clickOutsideDeactivates,
               returnFocusOnDeactivate: this.returnFocusOnDeactivate,
               onActivate: () => {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing
- [X] New/updated tests are included

The focus-trap package allows either a boolean or a callback function to be provided to its allowOutsideClick, whereas `focus-trap-vue` currently only allows a boolean to be provided.

Adding the ability to provide a callback function gives developers access to the `MouseEvent` emitted when a DOM element outside the focus trap is clicked, allowing them to dynamically determine whether or not the outside click should be allowed.

**Example use case**

A button, when clicked, activates a focus trap. When clicked again, the button deactivates the focus trap. This can only be accomplished if the developer has access to the `MouseEvent` in the `allowOutsideClick` callback so that they can check to see if the DOM element being clicked is the button and deactivate the focus trap. Without the ability to do this, clicking the button simply deactivates the focus trap and then immediately reactivates it again.