### PR TITLE
feat: function for the `allowOutsideClick` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ always focus an interactable element instead of the modal container:
 
 - `escapeDeactivates`: `boolean`
 - `returnFocusOnDeactivate`: `boolean`
-- `allowOutsideClick`: `boolean`
+- `allowOutsideClick`: `boolean | ((e: MouseEvent) => boolean)`
 - `clickOutsideDeactivates`: `boolean`
 - `initialFocus`: `string | (() => Element)` _Selector or function returning an Element_
 - `fallbackFocus`: `string | (() => Element)` _Selector or function returning an

--- a/cypress/integration/index.spec.js
+++ b/cypress/integration/index.spec.js
@@ -11,6 +11,7 @@ function activateTrapWithButton(id) {
   cy.get(`${id} .trap`)
     .should('not.have.class', 'is-active')
     .get(`${id} > p > button`)
+    .first()
     .click()
 }
 
@@ -92,8 +93,30 @@ describe('focus trap vue', () => {
     it('can escape the trap by clicking outside of the bounds of the focus trap', () => {
       activateTrapWithButton('#ocd')
       assertActivatedTrap('#ocd')
-      cy.get('body').click()
+      // force is needed because the vertical center of the body may not be
+      // visible and click always tries to click on the middle of an element
+      cy.get('body').click({ force: true })
       assertDeactivatedTrap('#ocd')
+    })
+  })
+
+  describe('conditionally allowing outside clicks', () => {
+    it('does not allow outside clicks when toggled off', () => {
+      activateTrapWithButton('#aoc')
+      assertActivatedTrap('#aoc')
+
+      activateTrapWithButton('#basic')
+      assertActivatedTrap('#aoc')
+    })
+
+    it('allows outside clicks when toggled on', () => {
+      cy.get('#aoc > p input[type="checkbox"]').check()
+
+      activateTrapWithButton('#aoc')
+      assertActivatedTrap('#aoc')
+
+      activateTrapWithButton('#basic')
+      assertActivatedTrap('#basic')
     })
   })
 })

--- a/demo/App.vue
+++ b/demo/App.vue
@@ -175,6 +175,55 @@
         </div>
       </focus-trap>
     </section>
+
+    <section id="aoc">
+      <h2 id="aoc-heading">allow outside click</h2>
+      <p>
+        A callback function can be used to determine whether or not you
+        should be allowed to click outside of the focus trap when it's
+        deactivated.
+      </p>
+      <p>
+        <label>
+          <input type="checkbox" v-model="demos.aoc.clickOutsideEnabled">
+          Enable outside clicking
+        </label>
+      </p>
+      <p>
+        <button @click="demos.aoc.isActive = true">
+          activate trap
+        </button>
+      </p>
+
+      <focus-trap
+        v-model:active="demos.aoc.isActive"
+        :initial-focus="demos.aoc.initialFocus"
+        :allow-outside-click="demos.aoc.allowOutsideClick"
+      >
+        <div class="trap" :class="demos.aoc.isActive && 'is-active'">
+          <p>
+            Here is a focus trap <a href="#">with</a> <a href="#">some</a>
+            <a href="#">focusable</a> parts.
+          </p>
+          <p>
+            <label class="inline-label">
+              Initially focused input
+              <input ref="ocdInput" />
+            </label>
+          </p>
+          <p>
+            <button @click="demos.aoc.isActive = false">
+              deactivate trap
+            </button>
+          </p>
+        </div>
+      </focus-trap>
+      <p>
+        <button @click="handleClickFromAOC">
+          Try clicking me after activating the focus trap!
+        </button>
+      </p>
+    </section>
   </div>
 </template>
 
@@ -199,9 +248,23 @@ export default {
         ocd: {
           isActive: false,
         },
+        aoc: {
+          isActive: false,
+          clickOutsideEnabled: false,
+          allowOutsideClick: () =>  this.demos.aoc.clickOutsideEnabled
+        }
       },
     }
   },
+  methods: {
+    handleClickFromAOC() {
+      if (this.demos.aoc.isActive) {
+        alert("Successfully clicked outside of FocusTrap")
+      } else {
+        alert("Active the FocusTrap first to see that you can allow clicks to escape conditionally")
+      }
+    }
+  }
 }
 </script>
 

--- a/src/FocusTrap.ts
+++ b/src/FocusTrap.ts
@@ -8,7 +8,11 @@ import {
   PropType,
   Comment,
 } from 'vue'
-import { createFocusTrap, FocusTrap as FocusTrapI } from 'focus-trap'
+import {
+  createFocusTrap,
+  FocusTrap as FocusTrapI,
+  MouseEventToBoolean,
+} from 'focus-trap'
 
 export const FocusTrap = defineComponent({
   props: {
@@ -26,7 +30,7 @@ export const FocusTrap = defineComponent({
       default: true,
     },
     allowOutsideClick: {
-      type: Boolean,
+      type: [Boolean, Function] as PropType<boolean | MouseEventToBoolean>,
       default: true,
     },
     clickOutsideDeactivates: {
@@ -56,7 +60,10 @@ export const FocusTrap = defineComponent({
             // has no effect if already activated
             trap = createFocusTrap(el.value, {
               escapeDeactivates: props.escapeDeactivates,
-              allowOutsideClick: () => props.allowOutsideClick,
+              allowOutsideClick: (e: MouseEvent | TouchEvent) =>
+                typeof props.allowOutsideClick === 'function'
+                  ? props.allowOutsideClick(e)
+                  : props.allowOutsideClick,
               returnFocusOnDeactivate: props.returnFocusOnDeactivate,
               clickOutsideDeactivates: props.clickOutsideDeactivates,
               onActivate: () => {

--- a/src/FocusTrap.ts
+++ b/src/FocusTrap.ts
@@ -60,9 +60,9 @@ export const FocusTrap = defineComponent({
             // has no effect if already activated
             trap = createFocusTrap(el.value, {
               escapeDeactivates: props.escapeDeactivates,
-              allowOutsideClick: (e: MouseEvent | TouchEvent) =>
+              allowOutsideClick: event =>
                 typeof props.allowOutsideClick === 'function'
-                  ? props.allowOutsideClick(e)
+                  ? props.allowOutsideClick(event)
                   : props.allowOutsideClick,
               returnFocusOnDeactivate: props.returnFocusOnDeactivate,
               clickOutsideDeactivates: props.clickOutsideDeactivates,


### PR DESCRIPTION
This is a forward-port of #328
Brings the ability to use a callback to conditionally determine if FocusTrap should allow clicks to occur outside of the trap instead of just a boolean flag.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#Pull-Request
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
