### PR TITLE
fix: Pick undyling HTMLElement from Vue component Proxy (#385)

### DIFF
--- a/cypress/integration/index.spec.js
+++ b/cypress/integration/index.spec.js
@@ -54,6 +54,14 @@ describe('focus trap vue', () => {
 
       assertDeactivatedTrap('#basic')
     })
+
+    it('works with vue components', () => {
+      activateTrapWithButton('#vue-components')
+      assertActivatedTrap('#vue-components')
+      cy.focused().should('have.class', 'trap').type('{esc}')
+
+      assertDeactivatedTrap('#vue-components')
+    })
   })
 
   describe('With Transitioning Element', () => {

--- a/demo/App.vue
+++ b/demo/App.vue
@@ -259,14 +259,35 @@
         </div>
       </focus-trap>
     </section>
+
+    <section id="vue-components">
+      <h2 id="vue-components-heading">Wrapping Vue Components</h2>
+
+      <p>
+        <button @click="demos.vueComponents.isActive = true">activate trap</button>
+      </p>
+
+      <focus-trap v-model:active="demos.vueComponents.isActive">
+        <my-component
+          class="trap"
+          :class="demos.vueComponents.isActive && 'is-active'"
+          tabindex="-1"
+        >
+          <p>
+            <button @click="demos.vueComponents.isActive = false">deactivate trap</button>
+          </p>
+        </my-component>
+      </focus-trap>
+    </section>
   </div>
 </template>
 
 <script>
 import { FocusTrap } from '/@/'
+import MyComponent from './components/MyComponent.vue'
 
 export default {
-  components: { FocusTrap },
+  components: { FocusTrap, MyComponent },
   data() {
     return {
       demos: {
@@ -290,7 +311,10 @@ export default {
         },
         methods: {
           isActive: false,
-        }
+        },
+        vueComponents: {
+          isActive: false,
+        },
       },
     }
   },

--- a/demo/components/MyComponent.vue
+++ b/demo/components/MyComponent.vue
@@ -1,0 +1,20 @@
+<template>
+  <article>
+    Here's a part from an imported Vue component.
+
+    Here's yet more focusables.
+    <input type="text" /><br />
+
+    <a href="#">Link A</a><br />
+    <a href="#">Link B</a><br />
+    <a href="#">Link C</a>
+
+    <slot></slot>
+  </article>
+</template>
+
+<script>
+export default {
+  name: 'MyComponent',
+}
+</script>

--- a/src/FocusTrap.ts
+++ b/src/FocusTrap.ts
@@ -7,6 +7,7 @@ import {
   onUnmounted,
   PropType,
   Comment,
+  ComponentPublicInstance,
 } from 'vue'
 import {
   createFocusTrap,
@@ -54,11 +55,23 @@ export const FocusTrap = defineComponent({
 
   setup(props, { slots, emit }) {
     let trap: FocusTrapI | null
-    const el = ref<HTMLElement | null>(null)
+    const el = ref<HTMLElement | ComponentPublicInstance | null>(null)
 
     const ensureTrap = () => {
       if (trap) {
         return
+      }
+
+      if (el === null || el?.value === null) {
+        throw new Error(
+          '[focus-trap-vue] FocusTrap requires exactly one child.'
+        )
+      }
+
+      if (!(el.value instanceof HTMLElement) && Reflect.has(el.value, '$el')) {
+        if (Reflect.get(el.value, '$el') instanceof HTMLElement) {
+          el.value = (el.value as ComponentPublicInstance).$el
+        }
       }
 
       const { initialFocus } = props


### PR DESCRIPTION
This PR aims to fix the issue in #385 (and #380).

As mentioned in #385, I'm not entirely sure if `ComponentPublicInstance` is the right type for arbitrary Vue components, and I am also rather unfamiliar with the internals of Vue, as I am mostly just a user of the framework.

But the basic idea is that we should make sure that the underlying or rendered `HTMLElement` is passed to `createFocusTrap` instead of a `Proxy` of a Vue component.

---

#### PR Summary

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**Does this PR introduce a breaking change?** (check one)

- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing
- [x] New/updated tests are included

---

PS: I've read the contribution guidelines but I still don't feel confident if what I'm doing is considered respectful or rude. Please feel free to point out if I'm doing something incorrectly.
