### PR TITLE
fix(props): Upgrade `focus-trap` to fix `initialFocus` prop types

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "conventional-changelog-cli": "^2.1.0",
     "cypress": "^7.4.0",
     "cypress-plugin-tab": "^1.0.1",
-    "focus-trap": "^6.0.1",
+    "focus-trap": "^6.7.0",
     "lint-staged": "^11.0.0",
     "pascalcase": "^1.0.0",
     "prettier": "^2.1.2",
@@ -100,7 +100,7 @@
   },
   "homepage": "https://github.com/posva/focus-trap-vue#readme",
   "peerDependencies": {
-    "focus-trap": "^6.0.0",
+    "focus-trap": "^6.7.0",
     "vue": "^3.0.0-rc.13"
   }
 }

--- a/src/FocusTrap.ts
+++ b/src/FocusTrap.ts
@@ -10,7 +10,7 @@ import {
 } from 'vue'
 import {
   createFocusTrap,
-  FocusTarget,
+  FocusTargetOrFalse,
   FocusTrap as FocusTrapI,
   MouseEventToBoolean,
 } from 'focus-trap'
@@ -39,7 +39,7 @@ export const FocusTrap = defineComponent({
       default: false,
     },
     initialFocus: {
-      type: [String, Function] as PropType<FocusTarget>,
+      type: [String, Function, Boolean] as PropType<FocusTargetOrFalse>,
     },
     fallbackFocus: {
       type: [String, Function] as PropType<string | (() => HTMLElement)>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2619,12 +2619,12 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-focus-trap@^6.0.1:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.4.0.tgz#e9951484fddf933d9b9b0e95b499f9420f6a54d6"
-  integrity sha512-RpH291GjfNhy1ek+Iwe00oCaqJN0sBaB+S/v7BpCIldf39IslPI7657nOZ6HwgoEHpjCmUJoAY+Mfgrm0rohvQ==
+focus-trap@^6.7.0:
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.7.2.tgz#02e63b12f4d4b3d00bfac4309cfd223e9b4ed44e"
+  integrity sha512-mRVv9QPCXITaDreu+pNXiPk1Rpn0WQtGvGrDo3Z/s2kdwtzFw/WOPfbLkdxWWvcahoInm9eRztuQOr1RNyQGrw==
   dependencies:
-    tabbable "^5.2.0"
+    tabbable "^5.2.1"
 
 follow-redirects@^1.10.0:
   version "1.14.1"
@@ -6005,10 +6005,10 @@ symbol-observable@^1.1.0:
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
-tabbable@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.2.0.tgz#4fba60991d8bb89d06e5d9455c92b453acf88fb2"
-  integrity sha512-0uyt8wbP0P3T4rrsfYg/5Rg3cIJ8Shl1RJ54QMqYxm1TLdWqJD1u6+RQjr2Lor3wmfT7JRHkirIwy99ydBsyPg==
+tabbable@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.2.1.tgz#e3fda7367ddbb172dcda9f871c0fdb36d1c4cd9c"
+  integrity sha512-40pEZ2mhjaZzK0BnI+QGNjJO8UYx9pP5v7BGe17SORTO0OEuuaAwQTkAp8whcZvqon44wKFOikD+Al11K3JICQ==
 
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
The `focus-trap` library was updated in version 6.7.0 to fix an
issue with the type used for the `initialFocus` option where passing
`false` or a function that returns `false` was not allowed.

The relevant release is tagged here:
https://github.com/focus-trap/focus-trap/releases/tag/v6.7.0

Updating the type to include the Boolean constructor will allow
users of the Vue component to pass the `false` literal for the
`:initial-focus` prop. A function returning `false` already passed
the Vue type check but in previous versions of `focus-trap` would
raise an error. This was also fixed in 6.7.0:

https://github.com/focus-trap/focus-trap/commit/14b0ee830bd6d25fd86bac38135a590f98f43d25#diff-a3ce29c1c993dbf3f968461bb3ff5e3f522d8b0c94cc2ca8f6b3ef7a9eda3621R209-R212

Updating the peer and dev dependencies to be at least 6.7.0
allows `vue-focus-trap` to have the correct behavior and types
and to match the latest documentation for the `focus-trap` library.