### PR TITLE
feat: Allow passing a function to clickOutsideDeactivates prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ always focus an interactable element instead of the modal container:
 
 - `escapeDeactivates`: `boolean`
 - `returnFocusOnDeactivate`: `boolean`
-- `allowOutsideClick`: `boolean | ((e: MouseEvent) => boolean)`
-- `clickOutsideDeactivates`: `boolean`
+- `allowOutsideClick`: `boolean | ((e: MouseEvent | TouchEvent) => boolean)`
+- `clickOutsideDeactivates`: `boolean | ((e: MouseEvent | TouchEvent) => boolean)`
 - `initialFocus`: `string | (() => Element)` _Selector or function returning an Element_
 - `fallbackFocus`: `string | (() => Element)` _Selector or function returning an
   Element_

--- a/src/FocusTrap.ts
+++ b/src/FocusTrap.ts
@@ -35,7 +35,9 @@ const FocusTrapProps = defineFocusTrapProps({
     default: true,
   },
 
-  clickOutsideDeactivates: Boolean,
+  clickOutsideDeactivates: [Boolean, Function] as PropType<
+    Options['clickOutsideDeactivates']
+  >,
 
   initialFocus: [String, Function, Boolean] as PropType<
     Options['initialFocus']


### PR DESCRIPTION
focus-trap allows [passing a function to the clickOutsideDeactivates option](https://github.com/focus-trap/focus-trap#usage).

`clickOutsideDeactivates {boolean | (e: MouseEvent | TouchEvent) => boolean}`

But this component only allows passing a boolean, which leads to incorrect warnings in the console.

`[Vue warn]: Invalid prop: type check failed for prop "clickOutsideDeactivates". Expected Boolean, got Function `

This PR updates this prop to match the definition in the focus-trap lib.