### PR TITLE
feat: add support for `tabbableOptions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ always focus an interactable element instead of the modal container:
 - `allowOutsideClick`: `boolean | ((e: MouseEvent | TouchEvent) => boolean)`
 - `clickOutsideDeactivates`: `boolean | ((e: MouseEvent | TouchEvent) => boolean)`
 - `initialFocus`: `string | (() => Element)` _Selector or function returning an Element_
-- `fallbackFocus`: `string | (() => Element)` _Selector or function returning an
-  Element_
+- `fallbackFocus`: `string | (() => Element)` _Selector or function returning an Element_
+- `tabbableOptions`: `object` _Options for [`tabbable`](https://github.com/focus-trap/tabbable#common-options)_
 
 Please, refer to
 [focus-trap](https://github.com/davidtheclark/focus-trap#focustrap--createfocustrapelement-createoptions)

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ always focus an interactable element instead of the modal container:
 - `clickOutsideDeactivates`: `boolean | ((e: MouseEvent | TouchEvent) => boolean)`
 - `initialFocus`: `string | (() => Element)` _Selector or function returning an Element_
 - `fallbackFocus`: `string | (() => Element)` _Selector or function returning an Element_
-- `tabbableOptions`: `object` _Options for [`tabbable`](https://github.com/focus-trap/tabbable#common-options)_
+- `tabbableOptions`: `FocusTrapTabbableOptions` _Options passed to `tabbableOptions`_
 
 Please, refer to
 [focus-trap](https://github.com/davidtheclark/focus-trap#focustrap--createfocustrapelement-createoptions)

--- a/src/FocusTrap.ts
+++ b/src/FocusTrap.ts
@@ -58,6 +58,8 @@ const FocusTrapProps = defineFocusTrapProps({
   setReturnFocus: [Object, String, Boolean, Function] as PropType<
     Options['setReturnFocus']
   >,
+
+  tabbableOptions: Object as PropType<Options['tabbableOptions']>,
 })
 
 export const FocusTrap = defineComponent({
@@ -117,6 +119,7 @@ export const FocusTrap = defineComponent({
         onPostDeactivate: () => emit('postDeactivate'),
         initialFocus: props.initialFocus,
         fallbackFocus: props.fallbackFocus,
+        tabbableOptions: props.tabbableOptions,
       }))
     }
 


### PR DESCRIPTION
This PR adds support for `tabbableOptions` so it can be passed down to `focus-trap` and `tabbable`, mainly to address [this problem](https://github.com/focus-trap/tabbable#testing-in-jsdom).