### PR TITLE
Update peerDep of focus-trap to 7.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   },
   "homepage": "https://github.com/posva/focus-trap-vue#readme",
   "peerDependencies": {
-    "focus-trap": "^6.7.0",
+    "focus-trap": "^7.2.0",
     "vue": "^3.0.0-rc.13"
   },
   "dependencies": {}


### PR DESCRIPTION
otherwise npm complains about conflicting peer dependency