### PR TITLE
fix: forward delayInitialFocus prop to createFocusTrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ always focus an interactable element instead of the modal container:
 - `clickOutsideDeactivates`: `boolean | ((e: MouseEvent | TouchEvent) => boolean)`
 - `initialFocus`: `string | (() => Element)` _Selector or function returning an Element_
 - `fallbackFocus`: `string | (() => Element)` _Selector or function returning an Element_
+- `delayInitialFocus`: `boolean`
 - `tabbableOptions`: `FocusTrapTabbableOptions` _Options passed to `tabbableOptions`_
 
 Please, refer to

--- a/src/FocusTrap.ts
+++ b/src/FocusTrap.ts
@@ -50,7 +50,7 @@ const FocusTrapProps = defineFocusTrapProps({
   checkCanReturnFocus: Function as PropType<Options['checkCanReturnFocus']>,
 
   delayInitialFocus: {
-    type: Boolean as PropType<Options['delayInitialFocus']>,
+    type: Boolean,
     default: true,
   },
 

--- a/src/FocusTrap.ts
+++ b/src/FocusTrap.ts
@@ -49,7 +49,10 @@ const FocusTrapProps = defineFocusTrapProps({
 
   checkCanReturnFocus: Function as PropType<Options['checkCanReturnFocus']>,
 
-  delayInitialFocus: { type: Boolean, default: true },
+  delayInitialFocus: {
+    type: Boolean as PropType<Options['delayInitialFocus']>,
+    default: true,
+  },
 
   document: Object as PropType<Options['document']>,
 
@@ -120,6 +123,7 @@ export const FocusTrap = defineComponent({
         initialFocus: props.initialFocus,
         fallbackFocus: props.fallbackFocus,
         tabbableOptions: props.tabbableOptions,
+        delayInitialFocus: props.delayInitialFocus,
       }))
     }
 


### PR DESCRIPTION
Hello 👋 
Was looking for a reason why my unit tests (`jest/@vue/test-utils`) started to fail after upgrading `focus-trap` to `7.x` and stumble upon this issue https://github.com/posva/focus-trap-vue/issues/389 and the correspondent [react package counterpart](https://github.com/focus-trap/focus-trap-react/issues/91). It turns out that you've added the prop definition but never passed it down to the `createFocusTrap` function. This fixes it.

P.S: this still does not fix my issue, had to downgrade to `6.9.4` again but now I'm 100% sure it's unrelated with `focus-trap-vue` 

P.S:2 the reason is this breaking [change from tabbable](https://github.com/focus-trap/tabbable/commit/a09ba0be3d680e54aef5e32449b8fb033780780b). Everything works as normal on the app env, but tests don't run without setting `displayCheck: 'legacy-full | none'`. — **EDIT**: context [issue](https://github.com/focus-trap/tabbable/issues/664). Also it's not because of lack o warning, both [tabbable](https://github.com/focus-trap/tabbable#testing-in-jsdom) and [focus-trap](https://github.com/focus-trap/tabbable#testing-in-jsdom) have dedicated readme sections warning that tests that ran on `jsdom` env might fail. Since `@vue/test-utils` is fairly common in the vue community, maybe it's worth adding a link to it on this wrapper as well?!