### PR TITLE
feat: add component name

### DIFF
--- a/src/FocusTrap.ts
+++ b/src/FocusTrap.ts
@@ -66,6 +66,7 @@ const FocusTrapProps = defineFocusTrapProps({
 })
 
 export const FocusTrap = defineComponent({
+  name: 'FocusTrap',
   props: Object.assign(
     {
       active: {


### PR DESCRIPTION
Stubbing the nameless component in [Vue Test Utils](https://test-utils.vuejs.org/) is impossible when used in <script setup> component. Adding a name makes it possible to stub.

```vue
<script setup>
// MyComponent
import { FocusTrap } from 'focus-trap-vue'
</script>

<template>
  <div>
    <FocusTrap>
      ...
    </FocusTrap>
  </div>
</template>

```

```js
mount(MyComponent, {
  global: {
    stubs: { FocusTrap: true } 
  },     
})
```